### PR TITLE
FIX: Make email optional

### DIFF
--- a/schemas/dataset.schema.json
+++ b/schemas/dataset.schema.json
@@ -43,8 +43,7 @@
           }
         },
         "required": [
-          "full_name",
-          "email"
+          "full_name"
         ]
       },
       "minItems": 1,
@@ -236,8 +235,7 @@
               }
             },
             "required": [
-              "full_name",
-              "email"
+              "full_name"
             ]
           },
           "minItems": 1,
@@ -302,8 +300,7 @@
               }
             },
             "required": [
-              "full_name",
-              "email"
+              "full_name"
             ]
           },
           "minItems": 1,

--- a/schemas/dataspace.schema.json
+++ b/schemas/dataspace.schema.json
@@ -42,7 +42,7 @@
             "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{4}$"
         }
       },
-      "required": ["full_name", "email"]
+      "required": ["full_name"]
     },
     "start_date": { "type": "string", "format": "date" },
     "end_date": { "type": "string", "format": "date" },


### PR DESCRIPTION
Email needs to be optional since it cannot be accessed via the Pangaea API, thus the Pangaea crawler can't create persons with emails.